### PR TITLE
feat: sync with upstream Erisa/cloudflared-docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 # Build container
-ARG GOVERSION=1.23
+ARG GOVERSION=1.24
 ARG ALPINEVERSION
 
 FROM --platform=${BUILDPLATFORM} \
     golang:$GOVERSION-alpine${ALPINEVERSION} AS build
-LABEL org.opencontainers.image.source="https://github.com/neil1145/cloudflared-docker"
 
 WORKDIR /src
 RUN apk --no-cache add git build-base bash
@@ -14,7 +13,6 @@ ENV GO111MODULE=on \
 
 ARG VERSION=master
 RUN git clone https://github.com/cloudflare/cloudflared --depth=1 --branch ${VERSION} .
-RUN bash -x .teamcity/install-cloudflare-go.sh
 
 # From this point on, step(s) are duplicated per-architecture
 ARG TARGETOS

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "CLOUDFLARED_VERSION" {
-    default = "2025.4.2"
+    default = "2025.11.1"
 }
 
 variable "LATEST" {
@@ -11,11 +11,11 @@ variable "MULTI_PLATFORM" {
 }
 
 variable "GOVERSION" {
-    default = "1.23.9"
+    default = "1.24.7"
 }
 
 variable "ALPINEVERSION" {
-    default = "3.21"
+    default = "3.22"
 }
 
 target "default" {


### PR DESCRIPTION
- Update cloudflared version from 2025.4.2 to 2025.11.1
- Update Go version from 1.23/1.23.9 to 1.24/1.24.7
- Update Alpine version from 3.21 to 3.22
- Remove cloudflare-go installation script (now built-in)
- Remove image source label